### PR TITLE
Automatically increment list's version number

### DIFF
--- a/tokenlist-mainnet.json
+++ b/tokenlist-mainnet.json
@@ -88,8 +88,8 @@
         }
     ],
     "version": {
-        "major": 0,
-        "minor": 0,
-        "patch": 1
+        "major": 1,
+        "minor": 5,
+        "patch": 0
     }
 }


### PR DESCRIPTION
This change adds version auto-increment logic aligned with [Uniswap’s token list versioning rules](https://github.com/Uniswap/token-lists/blob/main/src/tokenlist.schema.json):

- major: incremented when tokens are removed from the list or token addresses are changed
- minor: incremented when tokens are added to the list
- patch: incremented for any other changes to the list (metadata, keywords, etc.)

If there are no changes, the list's timestamp will remain unchanged.

Additionally, the list version is manually set to 1.5.0 to reflect cumulative changes from previous PRs, establishing the correct baseline for future automatic increments.