### PR TITLE
Remove pufETH's CoinGecko ID

### DIFF
--- a/mainnet/pufETH/data.json
+++ b/mainnet/pufETH/data.json
@@ -5,7 +5,6 @@
   "symbol": "pufETH",
   "decimals": 18,
   "extensions": {
-    "coinGeckoId": "pufeth",
     "bridgeInfo": {
       "protocol": "LayerZero OFT",
       "bridgeAddress": "0x37D6382B6889cCeF8d6871A8b60E667115eDDBcF"


### PR DESCRIPTION
It has been removed from CoinGecko