### PR TITLE
fix: fall back to viewBox when SVG logo lacks width/height

### DIFF
--- a/scripts/validate_tokens.py
+++ b/scripts/validate_tokens.py
@@ -351,6 +351,9 @@ def validate_cross_chain_metadata(
 def get_svg_dimensions(svg_path: Path) -> tuple[int | None, int | None]:
     """Extract width and height from an SVG file.
 
+    Falls back to the viewBox attribute when width/height are absent, since
+    SVGs exported without explicit pixel dimensions are common and valid.
+
     Args:
         svg_path: Path to the SVG file.
 
@@ -369,6 +372,14 @@ def get_svg_dimensions(svg_path: Path) -> tuple[int | None, int | None]:
             width = int(re.sub(r"[^0-9.]", "", width_str).split(".")[0])
             height = int(re.sub(r"[^0-9.]", "", height_str).split(".")[0])
             return width, height
+
+        view_box = root.get("viewBox")
+        if view_box:
+            parts = view_box.replace(",", " ").split()
+            if len(parts) == 4:
+                width = int(float(parts[2]))
+                height = int(float(parts[3]))
+                return width, height
 
         return None, None
     except Exception:


### PR DESCRIPTION
## Summary
- `get_svg_dimensions()` in `scripts/validate_tokens.py` only read the `width`/`height` XML attributes, so a valid square SVG exported with only a `viewBox` (a common shape from Figma/Illustrator) failed validation with "Could not extract dimensions." This contradicted the function's own error message, which already told contributors a `viewBox` was acceptable.
- Adds a fallback that parses `viewBox="minX minY width height"` when `width`/`height` attributes are absent, and uses its width/height for the square/min-size checks.

## Test plan
- [x] Ran `get_svg_dimensions()` against all 89 existing `mainnet/*/logo.svg` files — identical output before and after (no regression on width/height-attribute SVGs).
- [x] Synthetic viewBox-only SVG (`viewBox="0 0 256 256"`, no width/height attrs) now resolves to `(256, 256)` instead of failing.
- [x] SVG with no dimensions at all still correctly returns `(None, None)`.
- [x] `uv run ruff check` and `uv run ruff format --check` pass on the changed file.