### PR TITLE
fix: guard address validation against non-string values

### DIFF
--- a/scripts/validate_tokens.py
+++ b/scripts/validate_tokens.py
@@ -210,7 +210,7 @@ def validate_cross_chain_addresses(cross_chain: dict[str, Any]) -> list[str]:
         else:
             address = chain_data["address"]
             # For EVM chains, validate address format
-            if not isinstance(address, str) or not is_valid_address(address):
+            if type(address) is not str or not is_valid_address(address):
                 errors.append(f"Invalid address in crossChainAddresses[{chain_id}]: {address}")
 
         # Validate optional symbol field type
@@ -509,7 +509,7 @@ def validate_token_data(
 
     # Validate address
     address = data.get("address")
-    if not isinstance(address, str) or not is_valid_address(address):
+    if type(address) is not str or not is_valid_address(address):
         errors.append(f"Invalid address: {address}")
 
     # Validate name

--- a/scripts/validate_tokens.py
+++ b/scripts/validate_tokens.py
@@ -210,7 +210,7 @@ def validate_cross_chain_addresses(cross_chain: dict[str, Any]) -> list[str]:
         else:
             address = chain_data["address"]
             # For EVM chains, validate address format
-            if not is_valid_address(address):
+            if not isinstance(address, str) or not is_valid_address(address):
                 errors.append(f"Invalid address in crossChainAddresses[{chain_id}]: {address}")
 
         # Validate optional symbol field type
@@ -509,7 +509,7 @@ def validate_token_data(
 
     # Validate address
     address = data.get("address")
-    if not is_valid_address(address):
+    if not isinstance(address, str) or not is_valid_address(address):
         errors.append(f"Invalid address: {address}")
 
     # Validate name


### PR DESCRIPTION
## Summary
- `is_valid_address()` calls `re.match()` directly on the `address` field. If `address` in `data.json` isn't a string (e.g. a JSON number, `null`, or a list), this raises an uncaught `TypeError`.
- `validate_token_directory()` doesn't catch exceptions from `validate_token_data()`, so this `TypeError` propagates all the way up to `main()`'s top-level `except Exception`, printing `Unexpected error: ...` and aborting validation for **every** token in the run — not just the malformed one.
- Every other field validated in `validate_token_data()` (`name`, `symbol`, `chainId`, `decimals`) already checks `isinstance()` before further validation. The top-level `address` field and `crossChainAddresses[chain_id].address` did not follow this same pattern.
- Adds the missing `isinstance(address, str)` guard in both places, matching the existing style, so a bad `address` field now produces a normal, scoped `"Invalid address: ..."` error for that token instead of crashing the whole script.

## Test plan
- [x] Reproduced the crash in isolation: `validate_token_data({"address": 12345, ...}, ...)` raised `TypeError: expected string or bytes-like object` before the fix.
- [x] After the fix, the same input returns a normal error list including `"Invalid address: 12345"` — no crash.
- [x] Same fix verified for `crossChainAddresses[chain_id].address` (e.g. `{"1": {"address": 999999}}`).
- [x] Ran the address-format check against all 89 existing `mainnet/*/data.json` files — identical results before and after (no regression on valid string addresses).
- [x] `uv run ruff check` and `uv run ruff format --check` pass on the changed file.